### PR TITLE
Add getWolfPositions()

### DIFF
--- a/src/was/GameBoard.java
+++ b/src/was/GameBoard.java
@@ -344,6 +344,15 @@ public class GameBoard {
 
         return null;
     }
+    
+    /**
+     * Get the positions of all the wolves on the board
+     * 
+     * @return an ArrayList containing was.GameLocation objects, with x,y positions
+     */
+    public ArrayList<GameLocation> getWolfPositions() {
+        return findAllPlayersLoc(GamePiece.WOLF);
+    }
 
     /**
      * Get the positions of all the sheep on the board


### PR DESCRIPTION
Sometimes I've noticed you like to add multiple wolves in a game for the final demonstration. I thought this may be helpful since getWolfPosition() only returns a single wolf, and thus could put Sheep at a disadvantage if they aren't aware of the others (although arguably, a good Sheep may look at the GamePiece objects surrounding it).