### PR TITLE
Added check to ensure index is not out of bounds

### DIFF
--- a/src/was/GameBoard.java
+++ b/src/was/GameBoard.java
@@ -496,7 +496,8 @@ public class GameBoard {
      * @return true if cell X, Y is empty.
      */
     public boolean isEmptyCell(int x, int y) {
-        return isEmptyCell(getIndex(x, y));
+        int index = getIndex(x, y);
+        return index < board.size() && isEmptyCell(index);
     }
 
     boolean isEmptyCell(int i) {


### PR DESCRIPTION
A student noted that isEmptyCell() throws an IndexOutOfBounds exception when called on coordinates that fall outside the boundaries of the GameBoard, which appears to stem from getIndex(). This would attempt to make those indices appear to have obstacles, consistent with how getPiece() behaves under a similar situation.