### PR TITLE
Post round actions

### DIFF
--- a/src/was/GameBoard.java
+++ b/src/was/GameBoard.java
@@ -778,6 +778,7 @@ public class GameBoard {
 
         // initialize the players
         for (Player p : players) {
+            p.roundEnding();
             p.callInitialize();
         }
 
@@ -814,6 +815,8 @@ public class GameBoard {
             // de-construct the players
             // right now this just releases some streams if needed.
             for (Player p : players) {
+                // Call round-end functions
+                p.roundEnding();
                 p.finished();
             }
         }

--- a/src/was/GameBoard.java
+++ b/src/was/GameBoard.java
@@ -804,6 +804,13 @@ public class GameBoard {
                         }
                     }
                 }
+                
+                // Allow players to perform tasks before the round ends
+                for (Player p : players) {
+                    // Call round-end functions
+                    p.roundEnding();
+                }
+                
                 wasgamegrid.doPause();
                 wasgamegrid.hide();
                 wasgamegrid = null; // go away!
@@ -815,7 +822,6 @@ public class GameBoard {
             // right now this just releases some streams if needed.
             for (Player p : players) {
                 // Call round-end functions
-                p.roundEnding();
                 p.finished();
             }
         }

--- a/src/was/GameBoard.java
+++ b/src/was/GameBoard.java
@@ -778,7 +778,6 @@ public class GameBoard {
 
         // initialize the players
         for (Player p : players) {
-            p.roundEnding();
             p.callInitialize();
         }
 

--- a/src/was/GameBoard.java
+++ b/src/was/GameBoard.java
@@ -808,7 +808,7 @@ public class GameBoard {
                 // Allow players to perform tasks before the round ends
                 for (Player p : players) {
                     // Call round-end functions
-                    p.roundEnding();
+                    p.callRoundEnding();
                 }
                 
                 wasgamegrid.doPause();

--- a/src/was/Player.java
+++ b/src/was/Player.java
@@ -43,6 +43,7 @@ public abstract class Player {
     private static final int IS_KEEPING_BUSY = 3;
     private static final int WILL_EAT = 4;
     private static final int IS_ATTACKED = 5;
+    private static final int ROUND_ENDING = 6;
     boolean willNotMove = false;
     static boolean debuggable = true; // is set to false by class tournament code
     // not accessible from outside of was package.
@@ -478,6 +479,9 @@ public abstract class Player {
                 case WILL_EAT:
                     reason = "will_eat";
                     break;
+                case ROUND_ENDING:
+                    reason = "round_ending";
+                    break;
             }
 
             System.err.println("Player " + getClass().getName() + " timed out " + TIMEOUT + "ms max." + " in function " + reason);
@@ -532,6 +536,10 @@ public abstract class Player {
                     if (thePlayer instanceof WolfPlayer) {
                         ((WolfPlayer) thePlayer).isAttacked();
                     }
+                    break;
+                case ROUND_ENDING:
+                    m = null; // No moves as round is ending
+                    roundEnding();
                     break;
             }
 //        System.out.println(Thread.activeCount()-threadcount);
@@ -656,6 +664,9 @@ public abstract class Player {
                 case WILL_EAT:
                     reason = "will_eat";
                     break;
+                case ROUND_ENDING:
+                    reason = "round_ending";
+                    break;
             }
 
             System.err.println("Player " + thePlayer.getClass().getName() + " timed out " + TIMEOUT + "ms max." + " in function " + reason);
@@ -718,6 +729,10 @@ public abstract class Player {
 
     final void callIsAttacked() {
         callPlayerFunction(IS_ATTACKED);
+    }
+    
+    final void callRoundEnding() {
+        callPlayerFunction(ROUND_ENDING);
     }
 
     final Move calcMove() {

--- a/src/was/Player.java
+++ b/src/was/Player.java
@@ -58,6 +58,7 @@ public abstract class Player {
     private double allowedDistanceDivider = 1; // none for now
     PlayerProxy playerProxy = null;
     private int isBusyUntilTime = 0; // wolf is eating
+    private int scenarioNum = 0;
     GameBoard gb = null;
     //private int x = 0, y = 0; // location of this player
     GameLocation loc = new GameLocation(0,0);
@@ -174,7 +175,6 @@ public abstract class Player {
     abstract GamePiece getPiece();
 
     private boolean isDisqualified() {
-        int scenarioNum = gb.scenario.requested;
         Integer dc = (Integer) disqualifiedCount.get(this.getClass().getName() + ".Sc" + new Integer(scenarioNum));
         if (dc == null) {
             dc = 0;
@@ -184,7 +184,6 @@ public abstract class Player {
     }
 
     private void markDisqualified() {
-        int scenarioNum = gb.scenario.requested;
         String playerID = this.getClass().getName() + ".Sc" + new Integer(scenarioNum);
         Integer dc = (Integer) disqualifiedCount.get(playerID);
         if (dc == null) {
@@ -206,6 +205,7 @@ public abstract class Player {
     {
         if (this.gb == null) {
             this.gb = gb;
+            this.scenarioNum = gb.scenario.requested;
         } else {
             // this may happen when gameboard is scaled
             //  throw new RuntimeException("Player's gameboard is already set.  Player added twice?");
@@ -412,7 +412,7 @@ public abstract class Player {
         if (fn == MOVE) {
             Tournament.logPlayerMoveAttempt(this.getClass(), gb);
         }
-        if (isDisqualified()) {
+        if (fn != ROUND_ENDING && isDisqualified()) {
 
             if (fn == MOVE) {
                 Tournament.logPlayerCrash(this.getClass(), new RuntimeException("not playing (disqualified)"), gb);

--- a/src/was/Player.java
+++ b/src/was/Player.java
@@ -822,7 +822,16 @@ public abstract class Player {
      */
     private void isKeepingBusy() {
     }
-
+    
+    /**
+     * roundEnding()
+     * 
+     * Called once per round to allow the player to do any post-round 
+     * cleanup or results-saving actions
+     */
+    public void roundEnding() {
+    }
+    
     /**
      * Provide a string representation
      *


### PR DESCRIPTION
Adds the ability for a player to perform additional actions after the end of a round (ex. save data to a file, output results, etc.). Useful for applying machine learning to a player.

Not sure if you'll want to create a wrapper for this function to prevent crashing/timeouts from a player who fails to implement it properly. I attempted to do this, but with how callPlayerFunction() works it'll throw a NullPointerException since it's checking if the player has been disqualified (and at the point where I've called the function, the gameboard object has already been destroyed).
